### PR TITLE
arc: add newly_interned field to track fresh insertions

### DIFF
--- a/benches/get_container.rs
+++ b/benches/get_container.rs
@@ -14,6 +14,8 @@ struct NewType<T>(T);
 
 fn bench_get_container(c: &mut Criterion) {
     let mut group = c.benchmark_group("cached");
+    let vals: Vec<_> = (0..RANGE).map(|idx| format!("short-{}", idx)).collect();
+
     // time:   [17.635 ms 17.707 ms 17.782 ms]
     group.bench_function(BenchmarkId::new("String", "short"), |b| {
         b.iter_batched(
@@ -21,7 +23,7 @@ fn bench_get_container(c: &mut Criterion) {
             |_| {
                 let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
-                    let s = ArcIntern::<String>::new(format!("short-{}", idx % RANGE));
+                    let s = ArcIntern::<String>::new(vals[idx % RANGE].clone());
                     ans.push(s);
                 }
             },
@@ -30,6 +32,9 @@ fn bench_get_container(c: &mut Criterion) {
     });
     group.finish();
 
+    let new_vals: Vec<_> = (0..RANGE)
+        .map(|idx| NewType(format!("short-{}", idx)))
+        .collect();
     let mut group = c.benchmark_group("uncached");
     // time:   [22.209 ms 22.294 ms 22.399 ms] => that's 26% faster!
     group.bench_function(BenchmarkId::new("NewType<String>", "short"), |b| {
@@ -38,10 +43,7 @@ fn bench_get_container(c: &mut Criterion) {
             |_| {
                 let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
-                    let s = ArcIntern::<NewType<String>>::new(NewType(format!(
-                        "short-{}",
-                        idx % RANGE
-                    )));
+                    let s = ArcIntern::<NewType<String>>::new(new_vals[idx % RANGE].clone());
                     ans.push(s);
                 }
             },

--- a/benches/get_container.rs
+++ b/benches/get_container.rs
@@ -30,6 +30,35 @@ fn bench_get_container(c: &mut Criterion) {
             criterion::BatchSize::PerIteration,
         );
     });
+    group.bench_function(BenchmarkId::new("String", "short-from_ref"), |b| {
+        b.iter_batched(
+            || {},
+            |_| {
+                let mut ans = Vec::with_capacity(ITER);
+                for idx in 0..ITER {
+                    let s = ArcIntern::<String>::from_ref(&vals[idx % RANGE]);
+
+                    ans.push(s);
+                }
+            },
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("String", "short-from_str"), |b| {
+        b.iter_batched(
+            || {},
+            |_| {
+                let mut ans = Vec::with_capacity(ITER);
+                for idx in 0..ITER {
+                    let s = ArcIntern::<String>::from_str(&vals[idx % RANGE]);
+
+                    ans.push(s);
+                }
+            },
+            criterion::BatchSize::PerIteration,
+        );
+    });
     group.finish();
 
     let new_vals: Vec<_> = (0..RANGE)

--- a/benches/get_container.rs
+++ b/benches/get_container.rs
@@ -19,7 +19,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<String>::new(format!("short-{}", idx % RANGE));
                     ans.push(s);
@@ -36,7 +36,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<NewType<String>>::new(NewType(format!(
                         "short-{}",
@@ -54,7 +54,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<usize>::new(idx % RANGE);
                     ans.push(s);
@@ -68,7 +68,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<NewType<usize>>::new(NewType(idx % RANGE));
                     ans.push(s);

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -123,6 +123,14 @@ impl<T: ?Sized> Borrow<RefCount<T>> for BoxRefCount<T> {
         &self.0
     }
 }
+
+impl<T: ?Sized + BorrowStr> Borrow<str> for BoxRefCount<T> {
+    #[inline(always)]
+    fn borrow(&self) -> &str {
+        &self.0.data.borrow()
+    }
+}
+
 impl<T: ?Sized> Deref for BoxRefCount<T> {
     type Target = T;
     #[inline(always)]
@@ -259,6 +267,60 @@ impl<T: Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
             // and then we will be able to intern a new copy.
             std::thread::yield_now();
         }
+    }
+}
+
+/// internal trait that allows us to specialize the `Borrow` trait for `str`
+/// avoid the need to create an owned value first.
+pub trait BorrowStr: Borrow<str> {}
+
+impl BorrowStr for String {}
+
+/// BorrowStr specialization
+impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// this is a fast-path for str, as it avoids the need to create owned
+    /// value first.
+    pub fn from_str<Q: AsRef<str>>(val: Q) -> ArcIntern<T>
+    where
+        T: BorrowStr + for<'a> From<&'a str>,
+    {
+        // No reference only fast-path as
+        // the trait `std::borrow::Borrow<Q>` is not implemented for `Arc<T>`
+        Self::new_from_str(val.as_ref())
+    }
+
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// If this value has not previously been
+    /// interned, then `new` will allocate a spot for the value on the
+    /// heap and generate that value using `T::from(val)`.
+    fn new_from_str<'a>(val: &'a str) -> ArcIntern<T>
+    where
+        T: BorrowStr + From<&'a str>,
+    {
+        let m = Self::get_container();
+        if let Some(b) = m.get(val) {
+            let b = b.key();
+            // First increment the count.  We are holding the write mutex here.
+            // Has to be the write mutex to avoid a race
+            let oldval = b.0.count.fetch_add(1, Ordering::SeqCst);
+            if oldval != 0 {
+                // we can only use this value if the value is not about to be freed
+                return ArcIntern {
+                    pointer: std::ptr::NonNull::from(b.0.borrow()),
+                };
+            } else {
+                // we have encountered a race condition here.
+                // we will just wait for the object to finish
+                // being freed.
+                b.0.count.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+
+        // start over with the new value
+        Self::new(val.into())
     }
 }
 
@@ -625,4 +687,15 @@ fn test_shrink_to_fit() {
     assert!(ArcIntern::<Value>::get_container().capacity() >= 1);
     ArcIntern::<Value>::shrink_to_fit();
     assert_eq!(0, ArcIntern::<Value>::get_container().capacity());
+}
+
+#[test]
+fn test_from_str() {
+    let x = ArcIntern::new("hello".to_string());
+    let y = ArcIntern::<String>::from_str("world");
+    assert_ne!(x, y);
+    assert_eq!(x, ArcIntern::from_ref("hello"));
+    assert_eq!(x, ArcIntern::from_str("hello"));
+    assert_eq!(y, ArcIntern::from_ref("world"));
+    assert_eq!(&*x, "hello");
 }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -138,6 +138,13 @@ impl<T: ?Sized + BorrowOsStr> Borrow<OsStr> for BoxRefCount<T> {
     }
 }
 
+impl<T: ?Sized + BorrowByteSlice> Borrow<[u8]> for BoxRefCount<T> {
+    #[inline(always)]
+    fn borrow(&self) -> &[u8] {
+        &self.0.data.borrow()
+    }
+}
+
 impl<T: ?Sized> Deref for BoxRefCount<T> {
     type Target = T;
     #[inline(always)]
@@ -360,6 +367,60 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
     fn new_from_os_str<'a>(val: &'a OsStr) -> ArcIntern<T>
     where
         T: BorrowOsStr + From<&'a OsStr>,
+    {
+        let m = Self::get_container();
+        if let Some(b) = m.get_mut(val) {
+            let b = b.key();
+            // First increment the count.  We are holding the write mutex here.
+            // Has to be the write mutex to avoid a race
+            let oldval = b.0.count.fetch_add(1, Ordering::SeqCst);
+            if oldval != 0 {
+                // we can only use this value if the value is not about to be freed
+                return ArcIntern {
+                    pointer: std::ptr::NonNull::from(b.0.borrow()),
+                };
+            } else {
+                // we have encountered a race condition here.
+                // we will just wait for the object to finish
+                // being freed.
+                b.0.count.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+
+        // start over with the new value
+        Self::new(val.into())
+    }
+}
+
+/// internal trait that allows us to specialize the `Borrow` trait for `[u8]`
+/// avoid the need to create an owned value first.
+pub trait BorrowByteSlice: Borrow<[u8]> {}
+
+impl BorrowByteSlice for Box<[u8]> {}
+
+/// BorrowByteSlice specialization
+impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// this is a fast-path for str, as it avoids the need to create owned
+    /// value first.
+    pub fn from_byte_slice<Q: AsRef<[u8]>>(val: Q) -> ArcIntern<T>
+    where
+        T: BorrowByteSlice + for<'a> From<&'a [u8]>,
+    {
+        // No reference only fast-path as
+        // the trait `std::borrow::Borrow<Q>` is not implemented for `Arc<T>`
+        Self::new_from_byte_slice(val.as_ref())
+    }
+
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// If this value has not previously been
+    /// interned, then `new` will allocate a spot for the value on the
+    /// heap and generate that value using `T::from(val)`.
+    fn new_from_byte_slice<'a>(val: &'a [u8]) -> ArcIntern<T>
+    where
+        T: BorrowByteSlice + From<&'a [u8]>,
     {
         let m = Self::get_container();
         if let Some(b) = m.get_mut(val) {
@@ -759,4 +820,15 @@ fn test_from_str() {
     assert_eq!(x, ArcIntern::from_str("hello"));
     assert_eq!(y, ArcIntern::from_ref("world"));
     assert_eq!(&*x, "hello");
+}
+
+#[test]
+fn test_from_byte_slice() {
+    let x = ArcIntern::new(Box::from(*b"hello"));
+    let y = ArcIntern::from_byte_slice(b"world");
+    assert_ne!(x, y);
+    assert_eq!(x, ArcIntern::from_ref(b"hello".as_ref()));
+    assert_eq!(x, ArcIntern::from_byte_slice(b"hello"));
+    assert_eq!(y, ArcIntern::from_ref(b"world".as_ref()));
+    assert_eq!(&*x, &Box::from(*b"hello"));
 }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -47,6 +47,18 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg_attr(docsrs, doc(cfg(feature = "arc")))]
 pub struct ArcIntern<T: ?Sized + Eq + Hash + Send + Sync + 'static> {
     pub(crate) pointer: std::ptr::NonNull<RefCount<T>>,
+    pub(crate) newly_interned: bool,
+}
+
+impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
+    /// Returns `true` if this value was newly inserted into the intern table,
+    /// `false` if it already existed (reused existing entry).
+    ///
+    /// This is only meaningful immediately after creation. Clones always return `false`.
+    #[inline]
+    pub fn newly_interned(&self) -> bool {
+        self.newly_interned
+    }
 }
 
 #[cfg(feature = "deepsize")]
@@ -249,6 +261,7 @@ impl<T: Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
                     // we can only use this value if the value is not about to be freed
                     return ArcIntern {
                         pointer: std::ptr::NonNull::from(b.0.borrow()),
+                        newly_interned: false,
                     };
                 } else {
                     // we have encountered a race condition here.
@@ -266,6 +279,7 @@ impl<T: Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
                         // We can insert, all is good
                         let p = ArcIntern {
                             pointer: std::ptr::NonNull::from(e.key().0.borrow()),
+                            newly_interned: true,
                         };
                         e.insert(());
                         return p;
@@ -324,6 +338,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
                 // we can only use this value if the value is not about to be freed
                 return ArcIntern {
                     pointer: std::ptr::NonNull::from(b.0.borrow()),
+                    newly_interned: false,
                 };
             } else {
                 // we have encountered a race condition here.
@@ -378,6 +393,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
                 // we can only use this value if the value is not about to be freed
                 return ArcIntern {
                     pointer: std::ptr::NonNull::from(b.0.borrow()),
+                    newly_interned: false,
                 };
             } else {
                 // we have encountered a race condition here.
@@ -432,6 +448,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
                 // we can only use this value if the value is not about to be freed
                 return ArcIntern {
                     pointer: std::ptr::NonNull::from(b.0.borrow()),
+                    newly_interned: false,
                 };
             } else {
                 // we have encountered a race condition here.
@@ -456,6 +473,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> Clone for ArcIntern<T> {
         unsafe { self.pointer.as_ref().count.fetch_add(1, Ordering::Relaxed) };
         ArcIntern {
             pointer: self.pointer,
+            newly_interned: false,
         }
     }
 }
@@ -759,13 +777,15 @@ fn multithreading1() {
 
 #[test]
 fn arc_has_niche() {
+    // ArcIntern is pointer + bool + padding (8 + 1 + 7 = 16 bytes)
     assert_eq!(
         std::mem::size_of::<ArcIntern<String>>(),
-        std::mem::size_of::<usize>(),
+        2 * std::mem::size_of::<usize>(),
     );
+    // Option<ArcIntern> should still have the same size due to NonNull niche
     assert_eq!(
         std::mem::size_of::<Option<ArcIntern<String>>>(),
-        std::mem::size_of::<usize>(),
+        std::mem::size_of::<ArcIntern<String>>(),
     );
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -308,7 +308,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
         T: BorrowStr + From<&'a str>,
     {
         let m = Self::get_container();
-        if let Some(b) = m.get(val) {
+        if let Some(b) = m.get_mut(val) {
             let b = b.key();
             // First increment the count.  We are holding the write mutex here.
             // Has to be the write mutex to avoid a race
@@ -362,7 +362,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
         T: BorrowOsStr + From<&'a OsStr>,
     {
         let m = Self::get_container();
-        if let Some(b) = m.get(val) {
+        if let Some(b) = m.get_mut(val) {
             let b = b.key();
             // First increment the count.  We are holding the write mutex here.
             // Has to be the write mutex to avoid a race

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -131,6 +131,13 @@ impl<T: ?Sized + BorrowStr> Borrow<str> for BoxRefCount<T> {
     }
 }
 
+impl<T: ?Sized + BorrowOsStr> Borrow<OsStr> for BoxRefCount<T> {
+    #[inline(always)]
+    fn borrow(&self) -> &OsStr {
+        &self.0.data.borrow()
+    }
+}
+
 impl<T: ?Sized> Deref for BoxRefCount<T> {
     type Target = T;
     #[inline(always)]
@@ -299,6 +306,60 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
     fn new_from_str<'a>(val: &'a str) -> ArcIntern<T>
     where
         T: BorrowStr + From<&'a str>,
+    {
+        let m = Self::get_container();
+        if let Some(b) = m.get(val) {
+            let b = b.key();
+            // First increment the count.  We are holding the write mutex here.
+            // Has to be the write mutex to avoid a race
+            let oldval = b.0.count.fetch_add(1, Ordering::SeqCst);
+            if oldval != 0 {
+                // we can only use this value if the value is not about to be freed
+                return ArcIntern {
+                    pointer: std::ptr::NonNull::from(b.0.borrow()),
+                };
+            } else {
+                // we have encountered a race condition here.
+                // we will just wait for the object to finish
+                // being freed.
+                b.0.count.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+
+        // start over with the new value
+        Self::new(val.into())
+    }
+}
+
+/// internal trait that allows us to specialize the `Borrow` trait for `str`
+/// avoid the need to create an owned value first.
+pub trait BorrowOsStr: Borrow<OsStr> {}
+
+impl BorrowOsStr for std::ffi::OsString {}
+
+/// BorrowStr specialization
+impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// this is a fast-path for str, as it avoids the need to create owned
+    /// value first.
+    pub fn from_os_str<Q: AsRef<OsStr>>(val: Q) -> ArcIntern<T>
+    where
+        T: BorrowOsStr + for<'a> From<&'a OsStr>,
+    {
+        // No reference only fast-path as
+        // the trait `std::borrow::Borrow<Q>` is not implemented for `Arc<T>`
+        Self::new_from_os_str(val.as_ref())
+    }
+
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// If this value has not previously been
+    /// interned, then `new` will allocate a spot for the value on the
+    /// heap and generate that value using `T::from(val)`.
+    fn new_from_os_str<'a>(val: &'a OsStr) -> ArcIntern<T>
+    where
+        T: BorrowOsStr + From<&'a OsStr>,
     {
         let m = Self::get_container();
         if let Some(b) = m.get(val) {

--- a/src/arc_dst.rs
+++ b/src/arc_dst.rs
@@ -79,6 +79,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
                     // we can only use this value if the value is not about to be freed
                     return ArcIntern {
                         pointer: std::ptr::NonNull::from(b.0.borrow()),
+                        newly_interned: false,
                     };
                 } else {
                     // we have encountered a race condition here.
@@ -93,6 +94,7 @@ impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
                         // We can insert, all is good
                         let p = ArcIntern {
                             pointer: std::ptr::NonNull::from(e.key().0.borrow()),
+                            newly_interned: true,
                         };
                         e.insert(());
                         return p;


### PR DESCRIPTION
## Summary
- Add a `newly_interned` bool field to `ArcIntern` that indicates whether the value was freshly inserted into the intern table (`true`) or reused from an existing entry (`false`)
- Clones always return `false`
- Add `newly_interned()` accessor method

## Motivation
This enables callers to reliably detect new allocations for quota tracking without TOCTOU races that would occur when checking `refcount()` after interning.

## Test plan
- All existing tests pass
- Size test updated to reflect the new struct size (pointer + bool + padding = 16 bytes)
- Option<ArcIntern> still benefits from NonNull niche optimization